### PR TITLE
Plants receive images from Wikipedia

### DIFF
--- a/backend/src/main/java/com/happyplants/controller/WikipediaController.java
+++ b/backend/src/main/java/com/happyplants/controller/WikipediaController.java
@@ -1,0 +1,29 @@
+package com.happyplants.controller;
+
+import com.happyplants.service.WikipediaService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+// This controller is only intended to be used for testing
+
+@RestController
+@RequestMapping("/api/wikipedia")
+@Tag(name = "Wikipedia")
+public class WikipediaController {
+    private final WikipediaService wikipediaService;
+
+    public WikipediaController(WikipediaService wikipediaService) {
+        this.wikipediaService = wikipediaService;
+    }
+
+    @GetMapping("/image-url")
+    @Operation(summary = "Get image url by plant name")
+    public String getPlantImageUrl(@RequestParam(name = "plantName") String plantName) {
+        String url = wikipediaService.getPlantImageUrl(plantName);
+        return (url != null) ? url : "No image found for: " + plantName;
+    }
+}

--- a/backend/src/main/java/com/happyplants/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/happyplants/exception/GlobalExceptionHandler.java
@@ -41,4 +41,9 @@ public class GlobalExceptionHandler {
         return ProblemDetail.forStatusAndDetail(HttpStatus.NOT_FOUND, ex.getMessage());
     }
 
+    @ExceptionHandler(WikipediaException.class)
+    public ProblemDetail wikipediaSearchFailed(UserPlantNotFoundException ex) {
+        return ProblemDetail.forStatusAndDetail(HttpStatus.INTERNAL_SERVER_ERROR, ex.getMessage());
+    }
+
 }

--- a/backend/src/main/java/com/happyplants/exception/WikipediaException.java
+++ b/backend/src/main/java/com/happyplants/exception/WikipediaException.java
@@ -1,0 +1,7 @@
+package com.happyplants.exception;
+
+public class WikipediaException extends RuntimeException {
+    public WikipediaException(String plantName) {
+        super("Wikipedia search failed for '"+plantName+"'");
+    }
+}

--- a/backend/src/main/java/com/happyplants/service/UsersPlantService.java
+++ b/backend/src/main/java/com/happyplants/service/UsersPlantService.java
@@ -20,11 +20,13 @@ public class UsersPlantService {
     private final UsersPlantRepository usersPlantRepository;
     private final PlantService plantService;
     private final PerenualApiService perenualApiService;
+    private final WikipediaService wikipediaService;
 
-    public UsersPlantService(UsersPlantRepository usersPlantRepository, PlantService plantService, PerenualApiService perenualApiService) {
+    public UsersPlantService(UsersPlantRepository usersPlantRepository, PlantService plantService, PerenualApiService perenualApiService, WikipediaService wikipediaService) {
         this.usersPlantRepository = usersPlantRepository;
         this.plantService = plantService;
         this.perenualApiService = perenualApiService;
+        this.wikipediaService = wikipediaService;
     }
 
     public UserPlantDTO convertToDto(UsersPlant usersPlant, OffsetDateTime lastWateredAt, int timesWatered) {
@@ -65,6 +67,16 @@ public class UsersPlantService {
         usersPlant.setUser(user);
         usersPlant.setPlant(plant);
         usersPlant.setImageUrl(null);
+
+        String wikipediaImageUrl = null;
+
+        wikipediaImageUrl = wikipediaService.getPlantImageUrl(plant.getScientificName());
+        if (wikipediaImageUrl == null) {
+            wikipediaImageUrl = wikipediaService.getPlantImageUrl(plant.getCommonName());
+        }
+
+        usersPlant.setImageUrl(wikipediaImageUrl);
+
         return usersPlantRepository.save(usersPlant);
     }
 

--- a/backend/src/main/java/com/happyplants/service/WikipediaService.java
+++ b/backend/src/main/java/com/happyplants/service/WikipediaService.java
@@ -1,0 +1,106 @@
+package com.happyplants.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.happyplants.exception.WikipediaException;
+import org.springframework.stereotype.Service;
+
+import java.net.URI;
+import java.net.URLEncoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+
+@Service
+public class WikipediaService {
+    private final HttpClient client = HttpClient.newHttpClient();
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final String baseUrl = "https://en.wikipedia.org/";
+
+
+
+    public String getPlantImageUrl(String plantName) {
+        try {
+            String articleTitle = getFirstArticleTitle(plantName);
+
+            if (articleTitle == null) {
+                return null;
+            }
+
+            String articleTitleWithUnderscores = articleTitle.replace(' ', '_');
+            String encodedTitle = URLEncoder.encode(articleTitleWithUnderscores, StandardCharsets.UTF_8);
+
+            String url = baseUrl + "api/rest_v1/page/summary/" + encodedTitle;
+
+            HttpRequest request = HttpRequest.newBuilder()
+                    .uri(URI.create(url))
+                    .setHeader("User-Agent", "HappyPlants/1.0")
+                    .GET()
+                    .build();
+
+            HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+
+            if (response.statusCode() == 200) {
+                JsonNode root = objectMapper.readTree(response.body());
+                JsonNode originalImage = root.path("originalimage");
+
+                if (!originalImage.isMissingNode()) {
+                    JsonNode source = originalImage.path("source");
+                    if (!source.isMissingNode() && !source.isNull()) {
+                        return source.asText();
+                    }
+                }
+            }
+
+            return null;
+
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to fetch Wikipedia image for plant: " + plantName, e);
+        }
+    }
+
+    private String getFirstArticleTitle(String plantName) {
+        try {
+            String trimmedName = plantName;
+
+            int dashPosition = trimmedName.indexOf('-');
+            if (dashPosition >= 0) {
+                trimmedName = trimmedName.substring(0, dashPosition);
+            }
+
+            int pipePosition = trimmedName.indexOf('|');
+            if (pipePosition >= 0) {
+                trimmedName = trimmedName.substring(0, pipePosition);
+            }
+
+            String encodedSearch = URLEncoder.encode(trimmedName.trim(), StandardCharsets.UTF_8);
+            String url = baseUrl + "w/api.php?action=query&list=search&srsearch=" + encodedSearch + "&format=json";
+
+            HttpRequest request = HttpRequest.newBuilder()
+                    .uri(URI.create(url))
+                    .setHeader("User-Agent", "HappyPlants/1.0")
+                    .GET()
+                    .build();
+
+            HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+
+            if (response.statusCode() == 200) {
+                JsonNode root = objectMapper.readTree(response.body());
+                JsonNode searchArray = root.path("query").path("search");
+
+                if (searchArray.isArray() && !searchArray.isEmpty()) {
+                    JsonNode titleNode = searchArray.get(0).path("title");
+                    if (!titleNode.isMissingNode() && !titleNode.isNull()) {
+                        return titleNode.asText();
+                    }
+                }
+            }
+
+            return null;
+
+        } catch (Exception e) {
+            throw new WikipediaException(plantName);
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a `WikipediaService` which can return image urls based on input, like plant name. We need this because Perenual image urls are only valid for 24 hrs.

This PR also makes it so new UserPlants receive a Wikipedia image as they are created.