### PR TITLE
feat(watering): add history, undo history and prevent premature watering

### DIFF
--- a/backend/src/main/java/com/happyplants/controller/UserPlantController.java
+++ b/backend/src/main/java/com/happyplants/controller/UserPlantController.java
@@ -129,6 +129,20 @@ public class UserPlantController {
         return usersPlantService.getWateringHistory(user.getId(), userPlantId);
     }
 
+    @DeleteMapping("/{userPlantId}/waterings")
+    @Operation(summary = "Ta bort en specifik bevattning från historiken (Ångra)")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<Void> deleteWatering(
+            @PathVariable UUID userPlantId,
+            @RequestParam @org.springframework.format.annotation.DateTimeFormat(iso = org.springframework.format.annotation.DateTimeFormat.ISO.DATE_TIME) java.time.OffsetDateTime occuredAt,
+            Authentication auth
+    ) {
+        User user = userService.getCurrentUser(auth);
+        usersPlantService.deleteWatering(user.getId(), userPlantId, occuredAt);
+        return ResponseEntity.noContent().build();
+    }
+
+
     @PatchMapping("/{userPlantId}/nickname")
     @Operation(summary = "Update nickname for a user's plant")
     @PreAuthorize("isAuthenticated()")

--- a/backend/src/main/java/com/happyplants/service/UserPlantService.java
+++ b/backend/src/main/java/com/happyplants/service/UserPlantService.java
@@ -170,7 +170,24 @@ public class UserPlantService {
             throw new UnauthorizedUserPlantAccessException();
         }
 
+        Integer interval = plant.getWateringFrequencyDays();
         OffsetDateTime now = OffsetDateTime.now();
+
+        if (interval != null && interval > 0) {
+
+            List<WateredPlant> history = wateredPlantRepository.findHistory(userPlantId);
+
+            if (!history.isEmpty()) {
+                OffsetDateTime lastWatered = history.get(0).getId().getOccuredAt();
+
+                if (now.isBefore(lastWatered.plusDays(interval))) {
+                    throw new org.springframework.web.server.ResponseStatusException(
+                            org.springframework.http.HttpStatus.BAD_REQUEST,
+                            "Plantan är fortfarande mätt! Vänta tills intervallet har passerat."
+                    );
+                }
+            }
+        }
 
         WateredPlantId id = new WateredPlantId();
         id.setUsersPlantsId(userPlantId);
@@ -229,6 +246,21 @@ public class UserPlantService {
 
         plant.setImageUrl(imageUrl);
         usersPlantRepository.save(plant);
+    }
+
+    public void deleteWatering(UUID userId, UUID userPlantId, OffsetDateTime occuredAt) {
+        UsersPlant plant = usersPlantRepository.findById(userPlantId)
+                .orElseThrow(UserPlantNotFoundException::new);
+
+        if (!plant.getUser().getId().equals(userId)) {
+            throw new UnauthorizedUserPlantAccessException();
+        }
+
+        WateredPlantId id = new WateredPlantId();
+        id.setUsersPlantsId(userPlantId);
+        id.setOccuredAt(occuredAt);
+
+        wateredPlantRepository.findById(id).ifPresent(wateredPlantRepository::delete);
     }
 
 

--- a/frontend/src/pages/(auth-protected)/library/@id/+Page.tsx
+++ b/frontend/src/pages/(auth-protected)/library/@id/+Page.tsx
@@ -4,7 +4,7 @@ import {API_BASE_URL} from "@/config";
 import {toast} from "sonner";
 import SpinningLoader from "@/components/SpinningLoader";
 import {Leaf, Droplets, ArrowLeft} from "lucide-react";
-import {formatDistanceToNow} from "date-fns";
+import {formatDistanceToNow, addDays} from "date-fns";
 import {Badge} from "@/components/ui/badge";
 import {Card, CardContent} from "@/components/ui/card";
 import {usePageContext} from "vike-react/usePageContext";
@@ -31,6 +31,7 @@ import {
 export default function Page() {
     const pageContext = usePageContext();
     const {id} = pageContext.routeParams;
+
 
     const [userPlant, setUserPlant] = useState<UserPlantDTO | null>(null);
     const [isLoading, setIsLoading] = useState<boolean>(true);
@@ -138,6 +139,12 @@ export default function Page() {
         );
     }
 
+    const nextWateringDate = userPlant?.lastWateredAt && userPlant?.wateringFrequencyDays
+        ? addDays(new Date(userPlant.lastWateredAt), userPlant.wateringFrequencyDays)
+        : null;
+
+    const isTooSoon = nextWateringDate ? new Date() < nextWateringDate : false;
+
     const displayName = userPlant.nickname || userPlant.plant.commonName;
 
     return (
@@ -154,6 +161,7 @@ export default function Page() {
                         onClick={markAsWatered}
                         userPlant={userPlant}
                         isWatering={isWatering}
+                        disabled={isTooSoon}
                     />
                     <ConfigButton userPlant={userPlant} onReload={() => getPlant(true)}/>
                 </div>

--- a/frontend/src/pages/(auth-protected)/library/@id/ConfigButton.tsx
+++ b/frontend/src/pages/(auth-protected)/library/@id/ConfigButton.tsx
@@ -1,4 +1,5 @@
 import { Button } from "@/components/ui/button";
+import { WateringHistoryDialog } from "./WateringHistoryDialog";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -28,7 +29,7 @@ export default function ConfigButton({
   userPlant: UserPlantDTO;
   onReload: () => void;
 }) {
-  type DialogType = "nickname" | "image" | "watering" | "delete" | null;
+  type DialogType = "nickname" | "image" | "watering" | "delete" | "history" | null;
   const [activeDialog, setActiveDialog] = useState<DialogType>(null);
   const [isClearing, setIsClearing] = useState<boolean>(false);
 
@@ -146,7 +147,9 @@ export default function ConfigButton({
                   >
                     Modify interval
                   </DropdownMenuItem>
-                  <DropdownMenuItem disabled>View history</DropdownMenuItem>
+                  <DropdownMenuItem
+                  onSelect={() => setActiveDialog("history")}
+                  >View history</DropdownMenuItem>
                 </DropdownMenuSubContent>
               </DropdownMenuPortal>
             </DropdownMenuSub>
@@ -189,6 +192,13 @@ export default function ConfigButton({
         onClose={() => setActiveDialog(null)}
         userPlant={userPlant}
         onSuccess={onReload}
+      />
+
+      <WateringHistoryDialog
+          isOpen={activeDialog === "history"}
+          onClose={() => setActiveDialog(null)}
+          userPlant={userPlant}
+          onUpdate={onReload}
       />
     </>
   );

--- a/frontend/src/pages/(auth-protected)/library/@id/MarkAsWateredButton.tsx
+++ b/frontend/src/pages/(auth-protected)/library/@id/MarkAsWateredButton.tsx
@@ -7,10 +7,12 @@ export default function MarkAsWateredButton({
   userPlant,
   isWatering,
   onClick,
+  disabled,
 }: {
   userPlant: UserPlantDTO;
   isWatering: boolean;
   onClick: () => void;
+  disabled: boolean;
 }) {
   const lastWateredDate = userPlant.lastWateredAt
     ? parseISO(userPlant.lastWateredAt)
@@ -37,11 +39,11 @@ export default function MarkAsWateredButton({
     <Button
       variant="outline"
       className="bg-primary/10 hover:bg-primary/10 border-primary/50"
-      disabled={isRecentlyWatered}
+      disabled={isRecentlyWatered || disabled  }
       onClick={onClick}
     >
       <Droplet />
-      {isRecentlyWatered ? "Just watered" : "Mark as watered"}
+      {isRecentlyWatered ? "Just watered" : disabled ? "Too soon to water" : "Mark as watered"}
     </Button>
   );
 }

--- a/frontend/src/pages/(auth-protected)/library/@id/WateringHistoryDialog.tsx
+++ b/frontend/src/pages/(auth-protected)/library/@id/WateringHistoryDialog.tsx
@@ -1,0 +1,148 @@
+import {
+    Dialog,
+    DialogContent,
+    DialogHeader,
+    DialogTitle,
+} from "@/components/ui/dialog";
+import { useEffect, useState } from "react";
+import { API_BASE_URL } from "@/config";
+import type { UserPlantDTO } from "@/types/UserPlantDTO";
+import { format, addDays } from "date-fns";
+import SpinningLoader from "@/components/SpinningLoader";
+import { Droplets, CalendarClock, Trash2 } from "lucide-react";
+import { DialogDescription } from "@/components/ui/dialog";
+import { toast } from "sonner";
+
+interface WateringHistoryDialogProps {
+    isOpen: boolean;
+    onClose: () => void;
+    userPlant: UserPlantDTO;
+    onUpdate: () => void;
+}
+
+interface WateredPlantDTO {
+    occuredAt: string;
+}
+
+
+
+export function WateringHistoryDialog({ isOpen, onClose, userPlant, onUpdate}: WateringHistoryDialogProps) {
+
+    const [history, setHistory] = useState<WateredPlantDTO[]>([]);
+    const [isLoading, setIsLoading] = useState(false);
+
+    const nextWateringDate = userPlant.lastWateredAt && userPlant.wateringFrequencyDays
+        ? addDays(new Date(userPlant.lastWateredAt), userPlant.wateringFrequencyDays)
+        : null;
+
+    useEffect(() => {
+        if (isOpen) {
+            fetchHistory();
+        }
+    }, [isOpen]);
+
+    async function fetchHistory() {
+        setIsLoading(true);
+        try {
+            const response = await fetch(`${API_BASE_URL}/user/plants/${userPlant.id}/waterings`, {
+                credentials: "include",
+            });
+            if (response.ok) {
+                const data = await response.json();
+                setHistory(data);
+            }
+        } catch (error) {
+            console.error("Failed to fetch history", error);
+        } finally {
+            setIsLoading(false);
+        }
+    }
+
+    async function handleDelete(occuredAt: string) {
+        try {
+            const response = await fetch(
+                `${API_BASE_URL}/user/plants/${userPlant.id}/waterings?occuredAt=${encodeURIComponent(occuredAt)}`,
+                {
+                    method: "DELETE",
+                    credentials: "include",
+                }
+            );
+
+            if (!response.ok) {
+                toast.error("Could not remove watering");
+                return;
+            }
+
+            toast.success("Watering removed");
+
+            try {
+                await fetchHistory();
+                if (onUpdate) onUpdate();
+            } catch (refreshError) {
+                console.error("Could not refresh UI, but data is deleted:", refreshError);
+            }
+
+        } catch (error) {
+            console.error("Network or Server error:", error);
+            toast.error("An error occurred");
+        }
+    }
+
+    return (
+        <Dialog open={isOpen} onOpenChange={onClose}>
+            <DialogContent className="sm:max-w-md">
+                <DialogHeader>
+                    <DialogTitle>Watering History</DialogTitle>
+                    <DialogDescription className="text-sm text-muted-foreground italic">
+                        {userPlant.nickname || userPlant.plant.commonName}
+                    </DialogDescription>
+                </DialogHeader>
+
+                {nextWateringDate && (
+                    <div className="mb-4 p-3 rounded-lg border-2 border-green-200 bg-green-50 flex items-center gap-3">
+                        <CalendarClock className="h-5 w-5 text-green-600" />
+                        <div className="flex flex-col">
+                            <span className="text-xs text-green-700 uppercase font-bold">Next scheduled watering</span>
+                            <span className="text-sm font-semibold text-green-900">
+                                {format(new Date(nextWateringDate), "PPP p")}
+                            </span>
+                        </div>
+                    </div>
+                )}
+
+                <div className="flex flex-col gap-4 py-4 max-h-[60vh] overflow-y-auto">
+                    {isLoading ? (
+                        <div className="flex justify-center py-8">
+                            <SpinningLoader />
+                        </div>
+                    ) : history.length > 0 ? (
+                        <div className="space-y-3">
+                            {history.map((entry, index) => (
+                                <div key={index} className="flex items-center justify-between p-3 rounded-lg border bg-card group">
+                                    <div className="flex items-center gap-3">
+                                        <Droplets className="h-4 w-4 text-blue-500" />
+                                        <span className="text-sm font-medium">
+                                            {format(new Date(entry.occuredAt), "PPP p")}
+                                        </span>
+                                    </div>
+                                    <button
+                                        onClick={() => handleDelete(entry.occuredAt)}
+                                        className="text-muted-foreground hover:text-destructive transition-colors p-1"
+                                        title="Undo this watering"
+                                    >
+                                        <Trash2 className="h-4 w-4" />
+                                    </button>
+                                </div>
+                            ))}
+                        </div>
+                    ) : (
+                        <div className="text-center py-8 text-muted-foreground border-2 border-dashed rounded-lg">
+                            <p className="text-lg font-medium text-foreground">No history yet</p>
+                            <p className="text-sm">This plant hasn't been logged as watered yet.</p>
+                        </div>
+                    )}
+                </div>
+            </DialogContent>
+        </Dialog>
+    );
+}


### PR DESCRIPTION
- Added ability to remove watering events from history (undo functionality).
- Updated backend DeleteMapping to use RequestParam for better handling of ISO dates.
- Implemented UI logic to disable the watering button based on plant frequency.
- Added visual states for the watering button: "Just watered" and "Too soon to water".
- Fixed synchronization between history dialog and main plant page.